### PR TITLE
pass internally_dereference_ref flag to bravado and remove manual dereferencing

### DIFF
--- a/fuzz_lightyear/main.py
+++ b/fuzz_lightyear/main.py
@@ -54,10 +54,11 @@ def setup_client(
         return None
 
     try:
+        config = {'internally_dereference_refs': True}
         if not schema:
-            client = SwaggerClient.from_url(url)
+            client = SwaggerClient.from_url(url, config=config)
         else:
-            client = SwaggerClient.from_spec(schema, origin_url=url)
+            client = SwaggerClient.from_spec(schema, origin_url=url, config=config)
     except requests.exceptions.ConnectionError:
         return 'Unable to connect to server.'
     except (


### PR DESCRIPTION
Functionality added to [bravado-core](https://github.com/Yelp/bravado-core/pull/204) by @macisamuele ensures that all `params` on an `operation` exposed by the bravado client are dereferenced, which means we don't need to perform the dereferencing within fuzz-lightyear.

As a bonus, this solves for multi-file swagger specs, which was the original reason I made this change.