### PR TITLE
Adding TravisCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+matrix:
+  include:
+      - python: 3.6
+        env: TOXENV=py36
+      - python: 3.7
+        env: TOXENV=py37
+        dist: xenial # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      - python: pypy3
+        env: TOXENV=pypy3
+install:
+  - pip install tox
+script: make test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,3 @@ matrix:
 install:
   - pip install tox
 script: make test
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ matrix:
         env: TOXENV=py36
       - python: 3.7
         env: TOXENV=py37
+        sudo: required # required for Python >= 3.7 (travis-ci/travis-ci#9069)
         dist: xenial # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      - python: 3.7
+        env: TOXENV=pre-commit
       - python: pypy3
         env: TOXENV=pypy3
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,8 @@ matrix:
         env: TOXENV=py37
         sudo: required # required for Python >= 3.7 (travis-ci/travis-ci#9069)
         dist: xenial # required for Python >= 3.7 (travis-ci/travis-ci#9069)
-      - python: 3.7
+      - python: 3.6
         env: TOXENV=pre-commit
-      - python: pypy3
-        env: TOXENV=pypy3
 install:
   - pip install tox
 script: make test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 project = fuzz_lightyear
 # These should match the travis env list
-envlist = py36,py37,pypy3
+envlist = pre-commit,py36,py37,pypy3
 skip_missing_interpreters = true
 tox_pip_extensions_ext_venv_update = true
 
@@ -13,7 +13,6 @@ commands =
     coverage run -m pytest tests
     coverage report --show-missing --include=tests/* --fail-under 98
     coverage report --show-missing --include=fuzz_lightyear/* --fail-under 95
-    pre-commit run --all-files
     mypy fuzz_lightyear
 
 [testenv:venv]
@@ -23,8 +22,9 @@ commands =
     pre-commit install -f --install-hooks
 
 [testenv:pre-commit]
+basepython = python3.7
 deps = pre-commit >= 1.16.1
-commands = pre-commit {posargs}
+commands = pre-commit run --all-files
 
 [pep8]
 ignore = E501

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 project = fuzz_lightyear
 # These should match the travis env list
-envlist = pre-commit,py36,py37,pypy3
+envlist = pre-commit,py36,py37
 skip_missing_interpreters = true
 tox_pip_extensions_ext_venv_update = true
 


### PR DESCRIPTION
Created `.travis.yml`, shuffled some things around in `tox.ini`, and removed `pypy3` as an environment. (The latter two were to facilitate clean Travis builds)