### PR TITLE
URL encode path array variables

### DIFF
--- a/fuzz_lightyear/request.py
+++ b/fuzz_lightyear/request.py
@@ -19,11 +19,11 @@ from .output.logging import log
 from .output.util import print_warning
 from .supplements.abstraction import get_abstraction
 
-COLLECTION_FORMAT_ENCODING = {
-    'csv': '%2C',
-    'tsv': '%5Ct',
-    'pipes': '%7C',
-    'ssv': '%20',
+COLLECTION_FORMAT_CHARS = {
+    'csv': ',',
+    'tsv': '\t',
+    'pipes': '|',
+    'ssv': ' ',
 }
 
 
@@ -61,9 +61,8 @@ class FuzzingRequest:
         fuzzed_input: List,
         collection_format: str,
     ) -> str:
-        return COLLECTION_FORMAT_ENCODING[collection_format].join(
-            [str(i) for i in fuzzed_input],
-        )
+        separator = quote_plus(COLLECTION_FORMAT_CHARS[collection_format])
+        return separator.join([str(i) for i in fuzzed_input])
 
     def json(self) -> Dict[str, Any]:
         path = self._swagger_operation.path_name    # type: str

--- a/fuzz_lightyear/request.py
+++ b/fuzz_lightyear/request.py
@@ -48,6 +48,13 @@ class FuzzingRequest:
             self.operation_id,
         )
 
+    def _format_path(
+        self,
+        fuzzed_input: Any,
+    ) -> str:
+        formatted_input = fuzzed_input.strip('[]').replace(',', '%2C')
+        return formatted_input
+
     def json(self) -> Dict[str, Any]:
         path = self._swagger_operation.path_name    # type: str
         params = defaultdict(dict)                  # type: Dict[str, Dict[str, Any]]
@@ -57,7 +64,10 @@ class FuzzingRequest:
                     continue
 
                 if value.location == 'path':
-                    path = path.replace(f'{{{key}}}', str(self.fuzzed_input[key]))
+                    path = path.replace(
+                        f'{{{key}}}',
+                        self._format_path(self.fuzzed_input[key]),
+                    )
                 else:
                     params[value.location][key] = self.fuzzed_input[key]
 

--- a/fuzz_lightyear/request.py
+++ b/fuzz_lightyear/request.py
@@ -56,7 +56,7 @@ class FuzzingRequest:
             self.operation_id,
         )
 
-    def _format_array(
+    def _encode_array_in_path(
         self,
         fuzzed_input: List,
         collection_format: str,
@@ -74,7 +74,7 @@ class FuzzingRequest:
 
                 if value.location == 'path':
                     if value.param_spec['type'] == 'array':
-                        fuzzed_input = self._format_array(
+                        fuzzed_input = self._encode_array_in_path(
                             self.fuzzed_input[key],
                             value.param_spec.get('collectionFormat', 'csv'),
                         )

--- a/testing/vulnerable_app/app.py
+++ b/testing/vulnerable_app/app.py
@@ -2,6 +2,8 @@ from functools import lru_cache
 
 from flask import Flask
 
+from .util import ListConverter
+
 
 @lru_cache(maxsize=1)
 def get_current_application():
@@ -14,5 +16,6 @@ def create_app(debug=False):
 
     # Make trailing slashes in routes redundant.
     app.url_map.strict_slashes = False
+    app.url_map.converters['array'] = ListConverter
 
     return app

--- a/testing/vulnerable_app/util.py
+++ b/testing/vulnerable_app/util.py
@@ -1,3 +1,6 @@
+from werkzeug.routing import BaseConverter
+
+
 def get_name(name):
     """
     Blueprint names must be unique, and cannot contain dots.
@@ -8,3 +11,18 @@ def get_name(name):
     :type name: str
     """
     return name.split('.')[-1]
+
+
+class ListConverter(BaseConverter):
+
+    def __init__(self, url_map):
+        super(ListConverter, self).__init__(url_map)
+        self.delimiter = '%2C'
+
+    def to_python(self, value):
+        return value.split(self.delimiter)
+
+    def to_url(self, values):
+        return self.delimiter.join(
+            BaseConverter.to_url(value) for value in values
+        )

--- a/testing/vulnerable_app/util.py
+++ b/testing/vulnerable_app/util.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote_plus
+
 from werkzeug.routing import BaseConverter
 
 
@@ -17,7 +19,7 @@ class ListConverter(BaseConverter):
 
     def __init__(self, url_map):
         super(ListConverter, self).__init__(url_map)
-        self.delimiter = '%2C'
+        self.delimiter = quote_plus(',')
 
     def to_python(self, value):
         return value.split(self.delimiter)

--- a/testing/vulnerable_app/views/location.py
+++ b/testing/vulnerable_app/views/location.py
@@ -22,10 +22,6 @@ class VariousLocations(Resource):
     def post(self, path_id):
         return string_model.output()
 
-    @api.expect(location_parser)
-    def get(self, path_id):
-        return string_model.output()
-
 
 @api.marshal_with(string_model.format)
 @ns.route('/')

--- a/testing/vulnerable_app/views/location.py
+++ b/testing/vulnerable_app/views/location.py
@@ -22,6 +22,10 @@ class VariousLocations(Resource):
     def post(self, path_id):
         return string_model.output()
 
+    @api.expect(location_parser)
+    def get(self, path_id):
+        return string_model.output()
+
 
 @api.marshal_with(string_model.format)
 @ns.route('/')

--- a/testing/vulnerable_app/views/types.py
+++ b/testing/vulnerable_app/views/types.py
@@ -33,6 +33,23 @@ class ExpectArray(Resource):
     def put(self):
         return string_model.output()
 
+
+@ns.route('/path_array/<array:ids>')
+class ExpectPathArray(Resource):
+    @api.doc(params={
+        'ids': {
+            'type': 'array',
+            'collectionFormat': 'csv',
+            'in': 'path',
+            'items': {
+                'type': 'integer',
+            },
+        },
+    })
+    def get(self, ids):
+        return string_model.output()
+
+
 # TODO: I would do an `object` endpoint (that's different than a post body),
 #       but I don't know whether reqparse supports that.
 

--- a/tests/integration/request_test.py
+++ b/tests/integration/request_test.py
@@ -58,6 +58,21 @@ def test_send_specified_auth(mock_client):
     ).session == 'attacker_session'
 
 
+def test_str_encodes_array_path_parameters(mock_client):
+    request = FuzzingRequest(
+        operation_id='get_various_locations',
+        tag='location',
+        path_id='[1,2,3]',
+        query='a',
+        header='b',
+    )
+    request.send()
+    assert str(request) == (
+        'curl -X GET http://localhost:5000/location/1%2C2%2C3?query=a '
+        '-H \'header: b\''
+    )
+
+
 def test_str_encodes_array_query_parameters(mock_client):
     request = FuzzingRequest(
         operation_id='get_expect_array',
@@ -67,7 +82,6 @@ def test_str_encodes_array_query_parameters(mock_client):
             False,
         ],
     )
-
     assert str(request) == f'curl -X GET {URL}/types/array?array=True&array=False'
 
 

--- a/tests/integration/request_test.py
+++ b/tests/integration/request_test.py
@@ -31,7 +31,7 @@ def test_json(mock_client):
         },
     }
     assert str(request) == (
-        'curl -X POST http://localhost:5000/location/path?query=a '
+        f'curl -X POST {URL}/location/path?query=a '
         '--data \'form=b\' '
         '-H \'header: c\''
     )
@@ -66,7 +66,7 @@ def test_str_encodes_array_path_parameters(mock_client):
     )
     request.send()
     assert str(request) == (
-        'curl -X GET http://localhost:5000/types/path_array/1%2C2%2C3'
+        f'curl -X GET {URL}/types/path_array/1%2C2%2C3'
     )
 
 

--- a/tests/integration/request_test.py
+++ b/tests/integration/request_test.py
@@ -60,16 +60,13 @@ def test_send_specified_auth(mock_client):
 
 def test_str_encodes_array_path_parameters(mock_client):
     request = FuzzingRequest(
-        operation_id='get_various_locations',
-        tag='location',
-        path_id='[1,2,3]',
-        query='a',
-        header='b',
+        operation_id='get_expect_path_array',
+        tag='types',
+        ids=[1, 2, 3],
     )
     request.send()
     assert str(request) == (
-        'curl -X GET http://localhost:5000/location/1%2C2%2C3?query=a '
-        '-H \'header: b\''
+        'curl -X GET http://localhost:5000/types/path_array/1%2C2%2C3'
     )
 
 


### PR DESCRIPTION
This PR addresses issue #22.

Previously, array parameters in paths were treated as strings, leading to improper encoding. This adds support for URL encoding arrays.

Swagger supports 4 types of separators in path arrays: commas, spaces, pipes, and tabs ([source](https://swagger.io/docs/specification/2-0/describing-parameters/#array-and-multi-value-parameters)). The type is specified in the `collectionFormat` of the parameter, and the `collectionFormat` is checked when formatting the URL in `fuzz_lightyear/request.py`.

I added a test for a simple `csv` case as an example of how the formatting works- adding tests for `ssv`, `tsv`, and `pipes` seemed superfluous due there being no additional logic surrounding those formats.