### PR TITLE
Add support for setting bounds for integer fuzzing

### DIFF
--- a/fuzz_lightyear/fuzzer.py
+++ b/fuzz_lightyear/fuzzer.py
@@ -104,14 +104,14 @@ def _find_bounds(schema: Dict[str, Any]) -> Dict[str, Any]:
        By default, maximums and minimums in swagger are not exclusive"""
     bounds = {}
     if 'minimum' in schema:
-        bounds['minimum'] = schema['minimum']
+        bounds['min_value'] = schema['minimum']
         if schema.get('exclusiveMinimum'):
-            bounds['minimum'] += 1.0
+            bounds['min_vallue'] += 1.0
 
     if 'maximum' in schema:
-        bounds['maximum'] = schema['maximum']
+        bounds['max_value'] = schema['maximum']
         if schema.get('exclusiveMaximum'):
-            bounds['maximum'] -= 1.0
+            bounds['max_value'] -= 1.0
     return bounds
 
 
@@ -121,7 +121,7 @@ def _fuzz_number(
 ) -> SearchStrategy:
     # TODO: Handle all the optional qualifiers for numbers.
     # https://swagger.io/docs/specification/data-models/data-types/#numbers
-    bounds = _find_bounds(kwargs)
+    bounds = _find_bounds(parameter)
 
     return st.floats(**bounds)
 
@@ -132,7 +132,7 @@ def _fuzz_integer(
 ) -> SearchStrategy:
     # TODO: Handle all the optional qualifiers for numbers.
     # https://swagger.io/docs/specification/data-models/data-types/#numbers
-    bounds = _find_bounds(kwargs)
+    bounds = _find_bounds(parameter)
 
     return st.integers(**bounds)
 

--- a/tests/integration/fuzzer_test.py
+++ b/tests/integration/fuzzer_test.py
@@ -84,6 +84,20 @@ def test_booleans(mock_client, is_required):
         assert_randomness(factory, [None, True, False])
 
 
+def test_integers(mock_client):
+    schema = {
+        'name': 'key',
+        'type': 'integer',
+        'minimum': 0,
+        'maximum': 3,
+        'exclusiveMaximum': True,
+    }
+
+    factory = fuzz_parameters([('key', schema,)])
+
+    assert_randomness(factory, [None, 0, 1, 2, ])
+
+
 class TestArray:
 
     def test_basic(self, mock_client):


### PR DESCRIPTION
This PR address issue #5. 

`hypothesis` has support for setting (inclusive) upper and lower bounds for integer and numbers. We might have to be a bit more creative when addressing the other [specification for integers](https://swagger.io/docs/specification/data-models/data-types/#numbers), `multipleOf`.

Added a small test for fuzzing integers to confirm it works.