### PR TITLE
Add setup fixture for code execution prior to testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,3 +235,17 @@ def attacker_factory():
         }
     }
 ```
+
+### Setup Fixtures
+
+We can use setup fixtures to specify code that we'd like to run _before_ any
+tests are run. This allows developers to setup any custom configuration or
+external applications the test application relies on.
+
+```python
+import fuzz_lightyear
+
+@fuzz_lightyear.setup
+def setup_function():
+    print("This code will be executed before any tests are run")
+```

--- a/fuzz_lightyear/__init__.py
+++ b/fuzz_lightyear/__init__.py
@@ -4,3 +4,4 @@ from .supplements.auth import victim_account            # noqa: F401
 from .supplements.factory import register_factory       # noqa: F401
 from .supplements.request import custom_swagger_client  # noqa: F401
 from .supplements.request import make_request           # noqa: F401
+from .supplements.setup import setup                    # noqa: F401

--- a/fuzz_lightyear/datastore.py
+++ b/fuzz_lightyear/datastore.py
@@ -10,6 +10,17 @@ from typing import Tuple
 
 
 @lru_cache(maxsize=1)
+def get_setup_fixtures() -> List:
+    """
+    This is a global list that contains the functions that should be executed
+    before fuzz-lightyear begins executing tests.
+
+    :rtype: list(function)
+    """
+    return []
+
+
+@lru_cache(maxsize=1)
 def get_user_defined_mapping() -> Dict:
     """
     This is essentially a global variable, within a function scope, because
@@ -86,8 +97,8 @@ def inject_user_defined_variables(func: Callable) -> Callable:
 
             value = mapping[arg_name]()
             if (
-                arg_name in type_annotations and
-                not isinstance(type_annotations[arg_name], type(List))
+                arg_name in type_annotations
+                and not isinstance(type_annotations[arg_name], type(List))
             ):
                 # If type annotations are used, use that to cast
                 # values for input.

--- a/fuzz_lightyear/main.py
+++ b/fuzz_lightyear/main.py
@@ -9,6 +9,7 @@ from bravado.client import SwaggerClient
 from bravado.exception import HTTPError
 from swagger_spec_validator.common import SwaggerValidationError    # type: ignore
 
+from .datastore import get_setup_fixtures
 from .discovery import import_fixtures
 from .generator import generate_sequences
 from .output.interface import ResultFormatter
@@ -32,6 +33,8 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 1
 
     setup_fixtures(args.fixture)
+    run_user_defined_setup()
+
     outputter = run_tests(
         *args.test,
         iterations=args.iterations,
@@ -79,6 +82,11 @@ def setup_client(
 def setup_fixtures(fixtures: List[str]) -> None:
     for fixture_path in fixtures:
         import_fixtures(fixture_path)
+
+
+def run_user_defined_setup() -> None:
+    for function in get_setup_fixtures():
+        function()
 
 
 def run_tests(

--- a/fuzz_lightyear/supplements/setup.py
+++ b/fuzz_lightyear/supplements/setup.py
@@ -1,0 +1,23 @@
+from typing import Callable
+
+from fuzz_lightyear.datastore import get_setup_fixtures
+
+
+def setup(func: Callable) -> Callable:
+    """
+    Use the @setup decorator to mark functions that you'd like execute prior
+    to running fuzz-lightyear tests
+
+    Decorated functions should be in the file along with your factory fixtures
+
+    Basic use:
+
+        >>> import fuzz lightyear
+        >>> @fuzz_lightyear.setup
+        ... def setup_config():
+        ...     // do configuration here
+
+    """
+    setup_fixtures = get_setup_fixtures()
+    setup_fixtures.append(func)
+    return func

--- a/tests/unit/supplements/setup_supplements_test.py
+++ b/tests/unit/supplements/setup_supplements_test.py
@@ -1,0 +1,15 @@
+import fuzz_lightyear
+from fuzz_lightyear.main import run_user_defined_setup
+
+
+def test_setup():
+    count = 40
+
+    def setup_function():
+        nonlocal count
+        count = 50
+
+    fuzz_lightyear.setup(setup_function)
+    run_user_defined_setup()
+
+    assert count == 50


### PR DESCRIPTION
This PR addresses issue #16 .

The setup code is treated like any other fixture, and can be included in the file with all other fixtures. Right now it doesn't support setup functions that take in arguments. If that's the case, I'm imagining a tuple of `(func, args, kwargs)` or a dictionary where `func` maps to `(args, kwargs)`.