### PR TITLE
Add --disable-unicode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install fuzz-lightyear
 ```
 $ fuzz-lightyear -h
 usage: fuzz-lightyear [-h] [-v] [-n [ITERATIONS]] [--schema SCHEMA] [-f FIXTURE]
-                   [--seed SEED]
+                   [--seed SEED] [--disable-unicode]
                    url
 
 positional arguments:
@@ -55,6 +55,8 @@ optional arguments:
   -f FIXTURE, --fixture FIXTURE
                         Path to custom specified fixtures.
   --seed SEED           Specify seed for generation of random output.
+
+  --disable-unicode     Disable unicode characters in fuzzing, only use ASCII.
 ```
 
 ## Fixtures

--- a/fuzz_lightyear/fuzzer.py
+++ b/fuzz_lightyear/fuzzer.py
@@ -108,7 +108,7 @@ def _fuzz_string(
     if parameter.get('required', required):
         kwargs['min_size'] = 1
     if not get_settings().unicode_enabled:
-        kwargs['alphabet'] = string.ascii_letters
+        kwargs['alphabet'] = string.printable
 
     return st.text(**kwargs)
 

--- a/fuzz_lightyear/fuzzer.py
+++ b/fuzz_lightyear/fuzzer.py
@@ -12,6 +12,7 @@ from swagger_spec_validator.common import SwaggerValidationError    # type: igno
 
 from .datastore import get_user_defined_mapping
 from .output.logging import log
+from .settings import get_settings
 
 
 def fuzz_parameters(
@@ -102,10 +103,14 @@ def _fuzz_string(
 
     # TODO: Handle a bunch of swagger string formats.
     # https://swagger.io/docs/specification/data-models/data-types/#string
-    if parameter.get('required', required):
-        return st.text(min_size=1)
+    kwargs = {}                                     # type: Dict[str, Any]
 
-    return st.text()
+    if parameter.get('required', required):
+        kwargs['min_size'] = 1
+    if not get_settings().unicode_enabled:
+        kwargs['alphabet'] = string.ascii_letters
+
+    return st.text(**kwargs)
 
 
 def _find_bounds(schema: Dict[str, Any]) -> Dict[str, Any]:

--- a/fuzz_lightyear/main.py
+++ b/fuzz_lightyear/main.py
@@ -40,6 +40,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         iterations=args.iterations,
         seed=args.seed,
         ignore_exceptions=args.ignore_exceptions,
+        disable_unicode=args.disable_unicode,
     )
 
     outputter.show_results()
@@ -94,6 +95,7 @@ def run_tests(
     iterations: int = 1,
     seed: int = None,
     ignore_exceptions: bool = False,
+    disable_unicode: bool = False,
 ) -> ResultFormatter:
     """
     :param tests: list of tests to run.
@@ -102,9 +104,12 @@ def run_tests(
     :param iterations: size of request sequence to generate.
     :param seed: used for random generation of test input
     :param ignore_exceptions: if True, ignores HTTP exceptions to requests.
+    :param disable_unicode: if True, only use ASCII characters to fuzz strings
     """
     if seed is not None:
         get_settings().seed = seed
+    if disable_unicode:
+        get_settings().unicode_enabled = False
 
     outputter = ResultFormatter()
     for result in generate_sequences(

--- a/fuzz_lightyear/settings.py
+++ b/fuzz_lightyear/settings.py
@@ -10,14 +10,6 @@ class Settings:
         self.unicode_enabled = True            # type: bool
 
     @property
-    def unicode_enabled(self) -> bool:
-        return self._unicode_enabled
-
-    @unicode_enabled.setter
-    def unicode_enabled(self, value: bool) -> None:
-        self._unicode_enabled = value
-
-    @property
     def seed(self) -> int:
         return self._seed
 

--- a/fuzz_lightyear/settings.py
+++ b/fuzz_lightyear/settings.py
@@ -7,6 +7,15 @@ from hypothesis import core
 class Settings:
     def __init__(self) -> None:
         self.seed = random.getrandbits(128)    # type: int
+        self.unicode_enabled = True            # type: bool
+
+    @property
+    def unicode_enabled(self) -> bool:
+        return self._unicode_enabled
+
+    @unicode_enabled.setter
+    def unicode_enabled(self, value: bool) -> None:
+        self._unicode_enabled = value
 
     @property
     def seed(self) -> int:

--- a/fuzz_lightyear/usage.py
+++ b/fuzz_lightyear/usage.py
@@ -79,6 +79,15 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         ),
     )
 
+    parser.add_argument(
+        '--disable-unicode',
+        action='store_true',
+        help=(
+            'Disable fuzzing with unicode strings (only use ascii characters to '
+            'fuzz strings).'
+        ),
+    )
+
     return parser.parse_args(argv)
 
 


### PR DESCRIPTION
This PR addresses issue #2.

Add a `--disable-unicode` flag, and only fuzz with ASCII characters when the flag is included. This PR adds an addition `unicode_enabled` setting to `Settings()`, and its default is true. 