### PR TITLE
Add post fuzz hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,3 +323,5 @@ def apply_nonce(
     nonce = make_nonce()
     fuzzed_data['nonce'] = nonce
 ```
+
+Note: The order in which these hooks are run is not guaranteed.

--- a/README.md
+++ b/README.md
@@ -315,17 +315,11 @@ fuzzed data to a valid form.
 def apply_nonce(
     operation: bravado.client.CallableOperation,
     fuzzed_data: Dict[str, Any],
-) -> Dict[str, Any]:
+) -> None:
     """This hook creates and adds a nonce to any request against
     operations with the 'user' tag, and additionally to the
     'some_function' operation.
     """
     nonce = make_nonce()
-
-    new_data = fuzzed_data.copy()
-    if '_request_options' not in new_data:
-        new_data['_request_options'] = {}
-
-    new_data['_request_options']['nonce'] = nonce
-    return new_data
+    fuzzed_data['nonce'] = nonce
 ```

--- a/README.md
+++ b/README.md
@@ -298,3 +298,31 @@ def get_non_vulnerable_operations():
     # authentication.
     return ['get_user_public_profile']
 ```
+
+### Post-fuzz hooks
+
+Sometimes factory fixtures and random fuzzing are not sufficient to
+build a valid request. For example, the API could have an undeclared
+required header, and it is unfeasible to add the header to the
+Swagger spec. In this case, we can use post-fuzz hooks to transform
+fuzzed data to a valid form.
+
+```python
+@fuzz_lightyear.hooks.post_fuzz(
+    tags='user',
+    operations='some_function',
+)
+def apply_nonce(fuzzed_data: Dict[str, Any]) -> Dict[str, Any]:
+    """This hook creates and adds a nonce to any request against
+    operations with the 'user' tag, and additionally to the
+    'some_function' operation.
+    """
+    nonce = make_nonce()
+
+    new_data = fuzzed_data.copy()
+    if '_request_options' not in new_data:
+        new_data['_request_options'] = {}
+
+    new_data['_request_options']['nonce'] = nonce
+    return new_data
+```

--- a/README.md
+++ b/README.md
@@ -312,7 +312,10 @@ fuzzed data to a valid form.
     tags='user',
     operations='some_function',
 )
-def apply_nonce(fuzzed_data: Dict[str, Any]) -> Dict[str, Any]:
+def apply_nonce(
+    operation: bravado.client.CallableOperation,
+    fuzzed_data: Dict[str, Any],
+) -> Dict[str, Any]:
     """This hook creates and adds a nonce to any request against
     operations with the 'user' tag, and additionally to the
     'some_function' operation.

--- a/fuzz_lightyear/__init__.py
+++ b/fuzz_lightyear/__init__.py
@@ -1,4 +1,5 @@
 from .supplements import exclude                        # noqa: F401
+from .supplements import hooks                          # noqa: F401
 from .supplements import include                        # noqa: F401
 from .supplements.auth import attacker_account          # noqa: F401
 from .supplements.auth import victim_account            # noqa: F401

--- a/fuzz_lightyear/datastore.py
+++ b/fuzz_lightyear/datastore.py
@@ -10,16 +10,21 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 
+from bravado.client import CallableOperation
+
+
+PostFuzzHook = Callable[[CallableOperation, Dict[str, Any]], Dict[str, Any]]
+
 
 # These are module variables which contain the post-fuzz hooks
 # which have been registered. Each global allows fuzz_lightyear
 # to get a list applicable to a certain operation or tag.
-_POST_FUZZ_HOOKS_BY_OPERATION = defaultdict(set)  # type: Dict[str, Set[Callable]]
-_POST_FUZZ_HOOKS_BY_TAG = defaultdict(set)  # type: Dict[str, Set[Callable]]
+_POST_FUZZ_HOOKS_BY_OPERATION = defaultdict(set)  # type: Dict[str, Set[PostFuzzHook]]
+_POST_FUZZ_HOOKS_BY_TAG = defaultdict(set)  # type: Dict[str, Set[PostFuzzHook]]
 
 
 def register_post_fuzz_hook(
-    hook: Callable[[Dict[str, Any]], Dict[str, Any]],
+    hook: PostFuzzHook,
     operation_ids: Optional[List[str]] = None,
     tags: Optional[List[str]] = None,
 ) -> None:
@@ -51,7 +56,7 @@ def register_post_fuzz_hook(
 def get_post_fuzz_hooks(
     operation_id: str,
     tag: Optional[str] = None,
-) -> List[Callable[[Dict], Dict]]:
+) -> List[PostFuzzHook]:
     """Returns a list of functions that should be applied to fuzzed
     data for the input operation.
     """

--- a/fuzz_lightyear/datastore.py
+++ b/fuzz_lightyear/datastore.py
@@ -10,6 +10,17 @@ from typing import Set
 from typing import Tuple
 
 
+def get_post_fuzz_hooks(
+    operation_id: str,
+    tag: Optional[str] = None,
+) -> List[Callable[[Dict[str, Any]], Dict[str, Any]]]:
+    """Returns a list of functions that should be applied
+    to fuzzed data for the input operation.
+    """
+    # TODO: actually fill this in
+    return []
+
+
 @lru_cache(maxsize=1)
 def get_setup_fixtures() -> List:
     """

--- a/fuzz_lightyear/datastore.py
+++ b/fuzz_lightyear/datastore.py
@@ -13,7 +13,7 @@ from typing import Tuple
 from bravado.client import CallableOperation
 
 
-PostFuzzHook = Callable[[CallableOperation, Dict[str, Any]], Dict[str, Any]]
+PostFuzzHook = Callable[[CallableOperation, Dict[str, Any]], None]
 
 
 # These are module variables which contain the post-fuzz hooks

--- a/fuzz_lightyear/datastore.py
+++ b/fuzz_lightyear/datastore.py
@@ -32,6 +32,9 @@ def register_post_fuzz_hook(
     :param tags: A list of Swagger tags that the input hook applies
     to.
     """
+    if not operation_ids and not tags:
+        operation_ids = ['*']
+
     if not operation_ids:
         operation_ids = []
 
@@ -52,7 +55,9 @@ def get_post_fuzz_hooks(
     """Returns a list of functions that should be applied to fuzzed
     data for the input operation.
     """
-    operation_hooks = _POST_FUZZ_HOOKS_BY_OPERATION[operation_id]
+    operation_hooks = _POST_FUZZ_HOOKS_BY_OPERATION[operation_id].union(
+        _POST_FUZZ_HOOKS_BY_OPERATION['*'],
+    )
     tag_hooks = _POST_FUZZ_HOOKS_BY_TAG[tag] if tag else set()
     return list(operation_hooks.union(tag_hooks))
 

--- a/fuzz_lightyear/request.py
+++ b/fuzz_lightyear/request.py
@@ -144,8 +144,8 @@ class FuzzingRequest:
 
         # Empty dictionary means we're not sending parameters.
         if self.fuzzed_input is None:
-            fuzzed_input = self.fuzz(data)
-            self.fuzzed_input = self.apply_post_fuzz_hooks(fuzzed_input)
+            self.fuzzed_input = self.fuzz(data)
+            self.apply_post_fuzz_hooks(self.fuzzed_input)
 
         if not auth:
             auth = get_victim_session_factory()()
@@ -204,7 +204,7 @@ class FuzzingRequest:
 
         return fuzzed_input
 
-    def apply_post_fuzz_hooks(self, fuzzed_input: Dict[str, Any]) -> Dict[str, Any]:
+    def apply_post_fuzz_hooks(self, fuzzed_input: Dict[str, Any]) -> None:
         """After parameters for a request are fuzzed, this function
         applies developer-supplied post-fuzz hooks to the fuzzed
         input.
@@ -213,12 +213,10 @@ class FuzzingRequest:
         """
         hooks = get_post_fuzz_hooks(self.operation_id, self.tag)
         for hook in hooks:
-            fuzzed_input = hook(
+            hook(
                 self._swagger_operation,
                 fuzzed_input,
             )
-
-        return fuzzed_input
 
     @cached_property        # type: ignore
     def _swagger_operation(self) -> CallableOperation:

--- a/fuzz_lightyear/request.py
+++ b/fuzz_lightyear/request.py
@@ -213,7 +213,10 @@ class FuzzingRequest:
         """
         hooks = get_post_fuzz_hooks(self.operation_id, self.tag)
         for hook in hooks:
-            fuzzed_input = hook(fuzzed_input)
+            fuzzed_input = hook(
+                self._swagger_operation,
+                fuzzed_input,
+            )
 
         return fuzzed_input
 

--- a/fuzz_lightyear/request.py
+++ b/fuzz_lightyear/request.py
@@ -274,5 +274,12 @@ def _merge_kwargs(*args: Any) -> Dict[str, Any]:
     for dictionary in args:
         output.update(dictionary)
 
-    output.get('_request_options', {})['headers'] = headers
+    if not headers:
+        return output
+
+    if not output['_request_options']:
+        output['_request_options'] = {}
+
+    output['_request_options']['headers'] = headers
+
     return output

--- a/fuzz_lightyear/supplements/factory.py
+++ b/fuzz_lightyear/supplements/factory.py
@@ -16,6 +16,7 @@ from typing import Union
 from fuzz_lightyear.datastore import get_user_defined_mapping
 from fuzz_lightyear.datastore import inject_user_defined_variables
 from fuzz_lightyear.exceptions import ConflictingKeys
+from fuzz_lightyear.util import listify_decorator_args
 
 
 def register_factory(keys: Union[str, Iterable[str]]) -> Callable:
@@ -67,17 +68,14 @@ def register_factory(keys: Union[str, Iterable[str]]) -> Callable:
         ...     assert biz_id == '3'
         ...     return 4
     """
-    if isinstance(keys, str):
-        keys = [
-            key.strip()
-            for key in keys.split(',')
-        ]
+    # This is renamed just to make mypy happy.
+    _keys = listify_decorator_args(keys)
 
     def decorator(func: Callable) -> Callable:
         wrapped = inject_user_defined_variables(func)
 
         mapping = get_user_defined_mapping()
-        for key in keys:
+        for key in _keys:
             if key in mapping:
                 raise ConflictingKeys(key)
 

--- a/fuzz_lightyear/supplements/hooks.py
+++ b/fuzz_lightyear/supplements/hooks.py
@@ -1,0 +1,27 @@
+from typing import Callable
+from typing import Iterable
+from typing import Optional
+from typing import Union
+
+from fuzz_lightyear.datastore import register_post_fuzz_hook
+from fuzz_lightyear.util import listify_decorator_args
+
+
+def post_fuzz(
+    operations: Optional[Union[str, Iterable[str]]] = None,
+    tags: Optional[Union[str, Iterable[str]]] = None,
+) -> Callable:
+
+    # These are renamed just to make mypy happy.
+    operation_ids = listify_decorator_args(operations)
+    _tags = listify_decorator_args(tags)
+
+    def decorator(func: Callable) -> Callable:
+        register_post_fuzz_hook(
+            hook=func,
+            operation_ids=operation_ids,
+            tags=_tags,
+        )
+        return func
+
+    return decorator

--- a/fuzz_lightyear/util.py
+++ b/fuzz_lightyear/util.py
@@ -1,0 +1,27 @@
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Union
+
+
+def listify_decorator_args(
+    argument: Optional[Union[str, Iterable[str]]],
+) -> List[str]:
+    """Converts a user-supplied "list" to an actual Python list.
+    This helper supports a "string" list as follows:
+        >>> listify_decorator_args('a,b,c')
+        ['a', 'b', 'c']
+
+    :param argument: The argument to listify.
+    :return: A list of strings..
+    """
+    if not argument:
+        return []
+
+    if isinstance(argument, str):
+        return [
+            arg.strip()
+            for arg in argument.split(',')
+        ]
+
+    return list(argument)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from fuzz_lightyear.datastore import _POST_FUZZ_HOOKS_BY_OPERATION
+from fuzz_lightyear.datastore import _POST_FUZZ_HOOKS_BY_TAG
 from fuzz_lightyear.datastore import get_excluded_operations
 from fuzz_lightyear.datastore import get_included_tags
 from fuzz_lightyear.datastore import get_non_vulnerable_operations
@@ -18,3 +20,6 @@ def clear_caches():
     get_excluded_operations.cache_clear()
     get_non_vulnerable_operations.cache_clear()
     get_included_tags.cache_clear()
+
+    _POST_FUZZ_HOOKS_BY_OPERATION.clear()
+    _POST_FUZZ_HOOKS_BY_TAG.clear()

--- a/tests/integration/request_test.py
+++ b/tests/integration/request_test.py
@@ -117,7 +117,7 @@ def test_fuzzed_request(tag, id, mock_client):
     ],
 )
 def test_post_fuzz_hook(mock_client, decorator_args, fuzzing_request_args):
-    def post_fuzz_hook(fuzzed_input):
+    def post_fuzz_hook(operation, fuzzed_input):
         new_input = fuzzed_input.copy()
         if '_request_options' not in new_input:
             new_input['_request_options'] = {}

--- a/tests/integration/request_test.py
+++ b/tests/integration/request_test.py
@@ -118,15 +118,13 @@ def test_fuzzed_request(tag, id, mock_client):
 )
 def test_post_fuzz_hook(mock_client, decorator_args, fuzzing_request_args):
     def post_fuzz_hook(operation, fuzzed_input):
-        new_input = fuzzed_input.copy()
-        if '_request_options' not in new_input:
-            new_input['_request_options'] = {}
+        if '_request_options' not in fuzzed_input:
+            fuzzed_input['_request_options'] = {}
 
-        if 'headers' not in new_input['_request_options']:
-            new_input['_request_options']['headers'] = {}
+        if 'headers' not in fuzzed_input['_request_options']:
+            fuzzed_input['_request_options']['headers'] = {}
 
-        new_input['_request_options']['headers']['__test__'] = 'test'
-        return new_input
+        fuzzed_input['_request_options']['headers']['__test__'] = 'test'
 
     fuzz_lightyear.hooks.post_fuzz(**decorator_args)(post_fuzz_hook)
     request = FuzzingRequest(**fuzzing_request_args)

--- a/tests/unit/datastore_test.py
+++ b/tests/unit/datastore_test.py
@@ -15,7 +15,7 @@ class TestPostFuzzHooks:
         ),
     )
     def test_registering_hooks_by_operation(self, num_post_fuzz_hooks, operation_ids):
-        post_fuzz_hooks = {lambda x: x for __ in range(num_post_fuzz_hooks)}
+        post_fuzz_hooks = {lambda x, y: y for __ in range(num_post_fuzz_hooks)}
 
         for hook in post_fuzz_hooks:
             register_post_fuzz_hook(hook, operation_ids=operation_ids)
@@ -24,8 +24,8 @@ class TestPostFuzzHooks:
             assert set(get_post_fuzz_hooks(operation_id)) == post_fuzz_hooks
 
     def test_registering_hooks_all_operations(self):
-        def hook(x):
-            return x
+        def hook(x, y):
+            return y
         register_post_fuzz_hook(hook=hook)
 
         assert set(get_post_fuzz_hooks('random_operation')) == set([hook])

--- a/tests/unit/datastore_test.py
+++ b/tests/unit/datastore_test.py
@@ -22,3 +22,10 @@ class TestPostFuzzHooks:
 
         for operation_id in operation_ids:
             assert set(get_post_fuzz_hooks(operation_id)) == post_fuzz_hooks
+
+    def test_registering_hooks_all_operations(self):
+        def hook(x):
+            return x
+        register_post_fuzz_hook(hook=hook)
+
+        assert set(get_post_fuzz_hooks('random_operation')) == set([hook])

--- a/tests/unit/datastore_test.py
+++ b/tests/unit/datastore_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from fuzz_lightyear.datastore import get_post_fuzz_hooks
+from fuzz_lightyear.datastore import register_post_fuzz_hook
+
+
+class TestPostFuzzHooks:
+    @pytest.mark.parametrize(
+        ['num_post_fuzz_hooks', 'operation_ids'],
+        (
+            (1, ['tag1']),
+            (1, ['tag1', 'tag2']),
+            (2, ['tag1']),
+            (2, ['tag1', 'tag2']),
+        ),
+    )
+    def test_registering_hooks_by_operation(self, num_post_fuzz_hooks, operation_ids):
+        post_fuzz_hooks = {lambda x: x for __ in range(num_post_fuzz_hooks)}
+
+        for hook in post_fuzz_hooks:
+            register_post_fuzz_hook(hook, operation_ids=operation_ids)
+
+        for operation_id in operation_ids:
+            assert set(get_post_fuzz_hooks(operation_id)) == post_fuzz_hooks

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
     mypy fuzz_lightyear
 
 [testenv:venv]
-basepython = python3.7
+basepython = python3.6
 envdir = venv
 commands =
     pre-commit install -f --install-hooks

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
     mypy fuzz_lightyear
 
 [testenv:venv]
-basepython = python3.6
+basepython = python3.7
 envdir = venv
 commands =
     pre-commit install -f --install-hooks


### PR DESCRIPTION
This makes it so that developers can add their own headers and parameters to fuzzing requests, in case the Swagger spec is intentionally incomplete (some more details are available on internal Slack).

TODO: Actually provide an interface for developers to create hooks.

-----

I also moved a bunch of the fuzzing code to its own function to try to reduce nesting.