### PR TITLE
Improve test discovery algorithm

### DIFF
--- a/fuzz_lightyear/generator.py
+++ b/fuzz_lightyear/generator.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from functools import lru_cache
 from typing import Dict
 from typing import Iterator
 from typing import List
@@ -69,8 +70,8 @@ def generate_sequences(
                 if (
                     tests and not
                     (
-                        sequence[-1].id in tests or
-                        sequence[-1].tag in tests
+                        sequence[-1].id in tests
+                        or sequence[-1].tag in tests
                     )
                 ):
                     continue
@@ -120,6 +121,7 @@ def _add_request_to_sequence(
     return output
 
 
+@lru_cache(maxsize=1)
 def _generate_request_graph() -> Dict[str, set]:
     """
     Generates a directed graph, represented as an adjacency list.

--- a/fuzz_lightyear/generator.py
+++ b/fuzz_lightyear/generator.py
@@ -132,7 +132,7 @@ def _generate_request_graph() -> Dict[str, set]:
     """
     client = get_abstraction().client
     produces = defaultdict(list)  # type: Dict[str, List[str]]
-    consumes = defaultdict(list)  # type: Dict[str, List[str]]
+    consumes = {}  # type: Dict[str, List[str]]
 
     for tag_group in dir(client):
         for operation_id in dir(getattr(client, tag_group)):
@@ -142,8 +142,8 @@ def _generate_request_graph() -> Dict[str, set]:
                 response_params = list(
                     responses.get('schema', {}).get('properties', {}).keys(),
                 )
-            for response_param in response_params:
-                produces[response_param].append(operation_id)
+                for response_param in response_params:
+                    produces[response_param].append(operation_id)
 
             consumes[operation_id] = list(operation.params.keys())
 

--- a/tests/integration/generator_test.py
+++ b/tests/integration/generator_test.py
@@ -128,23 +128,41 @@ def test_length_three(mock_client):
     for sequence in sequences:
         assert len(sequence) <= 3
 
-        assert not is_in_result(
-            [
-                {
-                    'tag': 'basic',
-                    'id': 'get_public_listing',
-                },
-                {
-                    'tag': 'constant',
-                    'id': 'get_will_throw_error',
-                },
-                {
-                    'tag': 'basic',
-                    'id': 'get_public_listing',
-                },
-            ],
-            sequences,
-        )
+    assert not is_in_result(
+        [
+            {
+                'tag': 'basic',
+                'id': 'get_public_listing',
+            },
+            {
+                'tag': 'constant',
+                'id': 'get_will_throw_error',
+            },
+            {
+                'tag': 'basic',
+                'id': 'get_public_listing',
+            },
+        ],
+        sequences,
+    )
+
+    # Based on the request graph-based test discovery algorithm, operations should
+    # only be added to the sequence if they share an edge with at least one operation
+    # in the sequence. get_expect_path_array and get_expect_array do not share an edge
+    # and therefore there should be no sequence that only contains those two operations
+    assert not is_in_result(
+        [
+            {
+                'tag': 'types',
+                'id': 'get_expect_path_array',
+            },
+            {
+                'tag': 'types',
+                'id': 'get_expect_array',
+            },
+        ],
+        sequences,
+    )
 
 
 def is_in_result(expected_sequence, result):


### PR DESCRIPTION
**WIP**

This PR will be a hybrid of what is described in issue #8 and what is described in the [original research paper](https://arxiv.org/pdf/1806.09739.pdf). 

We'll start with the assumption that requests produce and consume single values: e.g. endpoint `/a` produces an integer `num` and `/b` consumes an integer `num`. For simplicity's sake, this is ignoring the case where some endpoint `/c` produces a dictionary that contains an integer `num` as one of its values.

To begin building a request graph, we need to know what endpoints produce and consume what values. So, two dictionaries are built: one that maps `operation_id`s to the resources they consume, and one that maps resources to the `operation_id`s that will produce them. 

From there, we construct a directed request graph. Every node is an `operation_id`, and an edge between two nodes `A` and `B` means that operation A consumes a resource that `B` produces. (This is because, as described in issue #8, we want to "work backwards" from one request. The graph is stored as an adjacency list. In the previous example, the graph would be represented as such:
```
{
     "A": ["B"],
}
```
~Afterwards, a DFS can occur, with a max depth of `n`, where `n` is a request sequence length specified by the user.~

Instead of conducting a DFS, we'll use the existing request sequence generating algorithm, but only add an operation to the sequence if it shares an edge with _any_ of the preceding operation in the sequence. This is because, for any given operation, we have no idea if the request associated it will use a previously produced value, fuzz a value, or use a factory _until we do the work to fuzz the request_. Opting to only add requests to the sequence if they share an edge with any previous request is in line with the algorithm described in the original research paper (which only adds requests to the sequence if _all_ of its parameters have been produced by previous requests), while reducing/simplifying the data structures needed and acknowledging that we may use factories or fuzz values.

**TESTING**
Testing poses an issue, and I'm still trying to think of an effective automated method of testing. I manually walked through request sequences with a debugger and found them to be what was expected. However, comparing a generated list of successful sequences to an expect list is probably not the best route for testing, as the results would be predicated on what endpoints are included in `vulnerable_app`, which may change!
**edit:** In regards to testing, after chatting with @domanchi, the conclusion was that creating tests that rely on `vulnerable_app` endpoints is inevitable, and that we check for sequences that _should not_ be in the list of sequences as opposed to checking for all possible sequences. I just added an assert to an existing test that builds a sequence, which I think is okay because it's an integration test.