### PR TITLE
Support yaml swagger schema in`--schema`

### DIFF
--- a/fuzz_lightyear/main.py
+++ b/fuzz_lightyear/main.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import requests
 import simplejson
+import yaml
 from bravado.client import SwaggerClient
 from bravado.exception import HTTPError
 from swagger_spec_validator.common import SwaggerValidationError    # type: ignore
@@ -67,10 +68,11 @@ def setup_client(
         return 'Unable to connect to server.'
     except (
         simplejson.errors.JSONDecodeError,      # type: ignore
+        yaml.YAMLError,
         HTTPError,
     ):
         return (
-            'Invalid swagger.json file. Please check to make sure the '
+            'Invalid swagger file. Please check to make sure the '
             'swagger file can be found at: {}.'.format(url)
         )
     except SwaggerValidationError:

--- a/fuzz_lightyear/usage.py
+++ b/fuzz_lightyear/usage.py
@@ -7,6 +7,13 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+import yaml
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader
+
+
 from fuzz_lightyear.version import VERSION
 
 
@@ -93,6 +100,14 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
 
 def _is_valid_schema(path: str) -> Dict[str, Any]:
     _is_valid_path(path)
+
+    if path.endswith('json'):
+        return _is_json_schema(path)
+    elif path.endswith(('yaml', 'yml')):
+        return _is_yaml_schema(path)
+
+
+def _is_json_schema(path: str) -> Dict[str, Any]:
     with open(path) as f:
         try:
             return cast(
@@ -102,6 +117,19 @@ def _is_valid_schema(path: str) -> Dict[str, Any]:
         except json.decoder.JSONDecodeError:
             raise argparse.ArgumentTypeError(
                 'Invalid JSON file: {}'.format(path),
+            )
+
+
+def _is_yaml_schema(path: str) -> Dict[str, Any]:
+    with open(path) as f:
+        try:
+            return cast(
+                Dict[str, Any],
+                yaml.load(f, loader=SafeLoader),
+            )
+        except yaml.YAMLError:
+            raise argparse.ArgumentTypeError(
+                'Invalid YAML file: {}'.format(path),
             )
 
 

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -2,3 +2,4 @@
 bravado
 cached-property
 hypothesis
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ msgpack-python==0.5.6
 pyrsistent==0.15.3
 python-dateutil==2.8.0
 pytz==2019.1
-PyYAML==5.1.1
+PyYAML==5.1.2
 requests==2.22.0
 rfc3987==1.3.8
 simplejson==3.16.0

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'bravado',
         'cached-property',
         'hypothesis',
+        'pyyaml',
     ],
     entry_points={
         'console_scripts': [

--- a/tests/integration/main_test.py
+++ b/tests/integration/main_test.py
@@ -40,7 +40,7 @@ class TestSetupClient:
         assert main.setup_client(url) == 'Unable to connect to server.'
 
     def test_invalid_schema_at_url(self, mock_server):
-        assert 'Invalid swagger.json file.' in main.setup_client(URL)
+        assert 'Invalid swagger file.' in main.setup_client(URL)
 
     def test_success_with_url_only(self, mock_server):
         assert not main.setup_client('{}/schema'.format(URL))


### PR DESCRIPTION
Before, the `--schema` flag only allowed json files. This change makes it so that the `--schema` flag can accept yaml files. We now use pyyaml to load the yaml file as a python dict and pass the dict to bravado. This is the same approach as JSON files.

If a file doesn't have a `json`, `yaml` or `yml` file extension, we'll try to load the file as json and yaml, and only raise an exception if the file can't be loaded either way.