### PR TITLE
Add rerun flag to post-fuzz hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ fuzzed data to a valid form.
 @fuzz_lightyear.hooks.post_fuzz(
     tags='user',
     operations='some_function',
+    rerun=True,
 )
 def apply_nonce(
     operation: bravado.client.CallableOperation,
@@ -323,6 +324,9 @@ def apply_nonce(
     """This hook creates and adds a nonce to any request against
     operations with the 'user' tag, and additionally to the
     'some_function' operation.
+
+    In addition, this nonce cannot be reused by a fuzz-lightyear
+    request object, so we mark this hook is needing to be `rerun`.
     """
     nonce = make_nonce()
     fuzzed_data['nonce'] = nonce

--- a/fuzz_lightyear/datastore.py
+++ b/fuzz_lightyear/datastore.py
@@ -19,14 +19,15 @@ PostFuzzHook = Callable[[CallableOperation, Dict[str, Any]], None]
 # These are module variables which contain the post-fuzz hooks
 # which have been registered. Each global allows fuzz_lightyear
 # to get a list applicable to a certain operation or tag.
-_POST_FUZZ_HOOKS_BY_OPERATION = defaultdict(set)  # type: Dict[str, Set[PostFuzzHook]]
-_POST_FUZZ_HOOKS_BY_TAG = defaultdict(set)  # type: Dict[str, Set[PostFuzzHook]]
+_ALL_POST_FUZZ_HOOKS_BY_OPERATION = defaultdict(set)  # type: Dict[str, Set[PostFuzzHook]]
+_ALL_POST_FUZZ_HOOKS_BY_TAG = defaultdict(set)  # type: Dict[str, Set[PostFuzzHook]]
 
 
 def register_post_fuzz_hook(
     hook: PostFuzzHook,
     operation_ids: Optional[List[str]] = None,
     tags: Optional[List[str]] = None,
+    rerun: bool = True,
 ) -> None:
     """Adds a post-fuzz hook to fuzz_lightyear's store of post-fuzz
     hooks.
@@ -47,10 +48,10 @@ def register_post_fuzz_hook(
         tags = []
 
     for operation_id in operation_ids:
-        _POST_FUZZ_HOOKS_BY_OPERATION[operation_id].add(hook)
+        _ALL_POST_FUZZ_HOOKS_BY_OPERATION[operation_id].add(hook)
 
     for tag in tags:
-        _POST_FUZZ_HOOKS_BY_TAG[tag].add(hook)
+        _ALL_POST_FUZZ_HOOKS_BY_TAG[tag].add(hook)
 
 
 def get_post_fuzz_hooks(
@@ -60,10 +61,10 @@ def get_post_fuzz_hooks(
     """Returns a list of functions that should be applied to fuzzed
     data for the input operation.
     """
-    operation_hooks = _POST_FUZZ_HOOKS_BY_OPERATION[operation_id].union(
-        _POST_FUZZ_HOOKS_BY_OPERATION['*'],
+    operation_hooks = _ALL_POST_FUZZ_HOOKS_BY_OPERATION[operation_id].union(
+        _ALL_POST_FUZZ_HOOKS_BY_OPERATION['*'],
     )
-    tag_hooks = _POST_FUZZ_HOOKS_BY_TAG[tag] if tag else set()
+    tag_hooks = _ALL_POST_FUZZ_HOOKS_BY_TAG[tag] if tag else set()
     return list(operation_hooks.union(tag_hooks))
 
 
@@ -164,8 +165,8 @@ def inject_user_defined_variables(func: Callable) -> Callable:
 
             value = mapping[arg_name]()
             if (
-                arg_name in type_annotations
-                and not isinstance(type_annotations[arg_name], type(List))
+                arg_name in type_annotations and
+                not isinstance(type_annotations[arg_name], type(List))
             ):
                 # If type annotations are used, use that to cast
                 # values for input.

--- a/fuzz_lightyear/datastore.py
+++ b/fuzz_lightyear/datastore.py
@@ -22,6 +22,11 @@ PostFuzzHook = Callable[[CallableOperation, Dict[str, Any]], None]
 _ALL_POST_FUZZ_HOOKS_BY_OPERATION = defaultdict(set)  # type: Dict[str, Set[PostFuzzHook]]
 _ALL_POST_FUZZ_HOOKS_BY_TAG = defaultdict(set)  # type: Dict[str, Set[PostFuzzHook]]
 
+# This probably isn't scalable if we add more parameters to
+# hooks , but for now this works, and is easy to understand.
+_RERUN_POST_FUZZ_HOOKS_BY_OPERATION = defaultdict(set)  # type: Dict[str, Set[PostFuzzHook]]  # noqa: E501
+_RERUN_POST_FUZZ_HOOKS_BY_TAG = defaultdict(set)  # type: Dict[str, Set[PostFuzzHook]]
+
 
 def register_post_fuzz_hook(
     hook: PostFuzzHook,
@@ -37,6 +42,8 @@ def register_post_fuzz_hook(
     applies to.
     :param tags: A list of Swagger tags that the input hook applies
     to.
+    :param rerun: Whether this hook needs to be rerun if a request
+    is rerun (for example, in the idor plugin).
     """
     if not operation_ids and not tags:
         operation_ids = ['*']
@@ -49,22 +56,35 @@ def register_post_fuzz_hook(
 
     for operation_id in operation_ids:
         _ALL_POST_FUZZ_HOOKS_BY_OPERATION[operation_id].add(hook)
+        if rerun:
+            _RERUN_POST_FUZZ_HOOKS_BY_OPERATION[operation_id].add(hook)
 
     for tag in tags:
         _ALL_POST_FUZZ_HOOKS_BY_TAG[tag].add(hook)
+        if rerun:
+            _RERUN_POST_FUZZ_HOOKS_BY_TAG[tag].add(hook)
 
 
 def get_post_fuzz_hooks(
     operation_id: str,
     tag: Optional[str] = None,
+    rerun: Optional[bool] = False,
 ) -> List[PostFuzzHook]:
     """Returns a list of functions that should be applied to fuzzed
     data for the input operation.
     """
-    operation_hooks = _ALL_POST_FUZZ_HOOKS_BY_OPERATION[operation_id].union(
-        _ALL_POST_FUZZ_HOOKS_BY_OPERATION['*'],
+    operation_hook_store = _RERUN_POST_FUZZ_HOOKS_BY_OPERATION \
+        if rerun \
+        else _ALL_POST_FUZZ_HOOKS_BY_OPERATION
+
+    tag_hook_store = _RERUN_POST_FUZZ_HOOKS_BY_TAG \
+        if rerun \
+        else _ALL_POST_FUZZ_HOOKS_BY_TAG
+
+    operation_hooks = operation_hook_store[operation_id].union(
+        operation_hook_store['*'],
     )
-    tag_hooks = _ALL_POST_FUZZ_HOOKS_BY_TAG[tag] if tag else set()
+    tag_hooks = tag_hook_store[tag] if tag else set()
     return list(operation_hooks.union(tag_hooks))
 
 

--- a/fuzz_lightyear/request.py
+++ b/fuzz_lightyear/request.py
@@ -145,7 +145,9 @@ class FuzzingRequest:
         # Empty dictionary means we're not sending parameters.
         if self.fuzzed_input is None:
             self.fuzzed_input = self.fuzz(data)
-            self.apply_post_fuzz_hooks(self.fuzzed_input)
+            self.apply_post_fuzz_hooks(self.fuzzed_input, rerun=False)
+        else:
+            self.apply_post_fuzz_hooks(self.fuzzed_input, rerun=True)
 
         if not auth:
             auth = get_victim_session_factory()()
@@ -204,14 +206,18 @@ class FuzzingRequest:
 
         return fuzzed_input
 
-    def apply_post_fuzz_hooks(self, fuzzed_input: Dict[str, Any]) -> None:
+    def apply_post_fuzz_hooks(
+        self,
+        fuzzed_input: Dict[str, Any],
+        rerun: Optional[bool] = False,
+    ) -> None:
         """After parameters for a request are fuzzed, this function
         applies developer-supplied post-fuzz hooks to the fuzzed
         input.
 
         :param fuzzed_input: The initial fuzz result from `self.fuzz`.
         """
-        hooks = get_post_fuzz_hooks(self.operation_id, self.tag)
+        hooks = get_post_fuzz_hooks(self.operation_id, self.tag, rerun)
         for hook in hooks:
             hook(
                 self._swagger_operation,

--- a/fuzz_lightyear/supplements/hooks.py
+++ b/fuzz_lightyear/supplements/hooks.py
@@ -10,6 +10,7 @@ from fuzz_lightyear.util import listify_decorator_args
 def post_fuzz(
     operations: Optional[Union[str, Iterable[str]]] = None,
     tags: Optional[Union[str, Iterable[str]]] = None,
+    rerun: bool = True,
 ) -> Callable:
 
     # These are renamed just to make mypy happy.
@@ -21,6 +22,7 @@ def post_fuzz(
             hook=func,
             operation_ids=operation_ids,
             tags=_tags,
+            rerun=rerun,
         )
         return func
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
-from fuzz_lightyear.datastore import _POST_FUZZ_HOOKS_BY_OPERATION
-from fuzz_lightyear.datastore import _POST_FUZZ_HOOKS_BY_TAG
+from fuzz_lightyear.datastore import _ALL_POST_FUZZ_HOOKS_BY_OPERATION
+from fuzz_lightyear.datastore import _ALL_POST_FUZZ_HOOKS_BY_TAG
 from fuzz_lightyear.datastore import get_excluded_operations
 from fuzz_lightyear.datastore import get_included_tags
 from fuzz_lightyear.datastore import get_non_vulnerable_operations
@@ -21,5 +21,5 @@ def clear_caches():
     get_non_vulnerable_operations.cache_clear()
     get_included_tags.cache_clear()
 
-    _POST_FUZZ_HOOKS_BY_OPERATION.clear()
-    _POST_FUZZ_HOOKS_BY_TAG.clear()
+    _ALL_POST_FUZZ_HOOKS_BY_OPERATION.clear()
+    _ALL_POST_FUZZ_HOOKS_BY_TAG.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import pytest
 
 from fuzz_lightyear.datastore import _ALL_POST_FUZZ_HOOKS_BY_OPERATION
 from fuzz_lightyear.datastore import _ALL_POST_FUZZ_HOOKS_BY_TAG
+from fuzz_lightyear.datastore import _RERUN_POST_FUZZ_HOOKS_BY_OPERATION
+from fuzz_lightyear.datastore import _RERUN_POST_FUZZ_HOOKS_BY_TAG
 from fuzz_lightyear.datastore import get_excluded_operations
 from fuzz_lightyear.datastore import get_included_tags
 from fuzz_lightyear.datastore import get_non_vulnerable_operations
@@ -23,3 +25,5 @@ def clear_caches():
 
     _ALL_POST_FUZZ_HOOKS_BY_OPERATION.clear()
     _ALL_POST_FUZZ_HOOKS_BY_TAG.clear()
+    _RERUN_POST_FUZZ_HOOKS_BY_OPERATION.clear()
+    _RERUN_POST_FUZZ_HOOKS_BY_TAG.clear()

--- a/tests/unit/datastore_test.py
+++ b/tests/unit/datastore_test.py
@@ -6,22 +6,33 @@ from fuzz_lightyear.datastore import register_post_fuzz_hook
 
 class TestPostFuzzHooks:
     @pytest.mark.parametrize(
-        ['num_post_fuzz_hooks', 'operation_ids'],
-        (
-            (1, ['tag1']),
-            (1, ['tag1', 'tag2']),
-            (2, ['tag1']),
-            (2, ['tag1', 'tag2']),
-        ),
+        'num_post_fuzz_hooks',
+        [1, 2],
     )
-    def test_registering_hooks_by_operation(self, num_post_fuzz_hooks, operation_ids):
+    @pytest.mark.parametrize(
+        'operation_ids',
+        [
+            ['tag1'],
+            ['tag1, tag2'],
+        ],
+    )
+    @pytest.mark.parametrize(
+        'rerun',
+        [True, False],
+    )
+    def test_registering_hooks_by_operation(
+        self,
+        num_post_fuzz_hooks,
+        operation_ids,
+        rerun,
+    ):
         post_fuzz_hooks = {lambda x, y: y for __ in range(num_post_fuzz_hooks)}
 
         for hook in post_fuzz_hooks:
-            register_post_fuzz_hook(hook, operation_ids=operation_ids)
+            register_post_fuzz_hook(hook, operation_ids=operation_ids, rerun=rerun)
 
         for operation_id in operation_ids:
-            assert set(get_post_fuzz_hooks(operation_id)) == post_fuzz_hooks
+            assert set(get_post_fuzz_hooks(operation_id, rerun=rerun)) == post_fuzz_hooks
 
     def test_registering_hooks_all_operations(self):
         def hook(x, y):


### PR DESCRIPTION
While trying to add this internally, I found a use case where we need to rerun a hook. Specifically, when a server reads a nonce from the request, we need to regenerate this nonce on every new request. If this nonce is generated by a hook, then we can just re-run the hook to generate the nonce.

This PR adds a `rerun` parameter to the hook decorator so that fuzz-lightyear can rerun the hook if the same request is sent twice. Test included.

TODO: readme