### PR TITLE
Update functions to use newer version of Hypothesis

### DIFF
--- a/fuzz_lightyear/fuzzer.py
+++ b/fuzz_lightyear/fuzzer.py
@@ -7,7 +7,7 @@ from typing import Optional
 from typing import Tuple
 
 import hypothesis.strategies as st
-from hypothesis.searchstrategy.strategies import SearchStrategy
+from hypothesis.strategies import SearchStrategy
 from swagger_spec_validator.common import SwaggerValidationError    # type: ignore
 
 from .datastore import get_user_defined_mapping

--- a/fuzz_lightyear/request.py
+++ b/fuzz_lightyear/request.py
@@ -12,7 +12,7 @@ from urllib.parse import urlencode
 from bravado.client import CallableOperation
 from bravado_core.param import get_param_type_spec      # type: ignore
 from cached_property import cached_property             # type: ignore
-from hypothesis.searchstrategy.strategies import SearchStrategy
+from hypothesis.strategies import SearchStrategy
 
 from .datastore import get_post_fuzz_hooks
 from .fuzzer import fuzz_parameters

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ coverage==4.5.4
 filelock==3.0.12
 Flask==1.1.1
 flask-restplus==0.13.0
-hypothesis==4.34.0
+hypothesis==4.56.1
 identify==1.4.7
 idna==2.8
 importlib-metadata==0.19

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -1,5 +1,5 @@
 # Remember to update setup.py when making changes to this file.
 bravado
 cached-property
-hypothesis
+hypothesis>=4.56.1
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bravado-core==5.13.1
 cached-property==1.5.1
 certifi==2019.6.16
 chardet==3.0.4
-hypothesis==4.28.2
+hypothesis==4.56.1
 idna==2.8
 jsonpointer==2.0
 jsonref==0.2

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=[
         'bravado',
         'cached-property',
-        'hypothesis',
+        'hypothesis>=4.56.1',
         'pyyaml',
     ],
     entry_points={


### PR DESCRIPTION
See https://github.com/Yelp/fuzz-lightyear/issues/40.

Fuzz-lightyear uses Hypothesis's internal APIs, which have changed recently. This updates the required version of Hypothesis to a more recent one, and updates the imports to prevent errors.