### PR TITLE
Reduce test noisiness

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ idna==2.8
 importlib-metadata==0.19
 importlib-resources==1.0.2
 itsdangerous==1.1.0
-Jinja2==2.10.1
+Jinja2==2.10.3
 jsonpointer==2.0
 jsonref==0.2
 jsonschema==3.0.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from fuzz_lightyear.datastore import _ALL_POST_FUZZ_HOOKS_BY_OPERATION
@@ -27,3 +29,19 @@ def clear_caches():
     _ALL_POST_FUZZ_HOOKS_BY_TAG.clear()
     _RERUN_POST_FUZZ_HOOKS_BY_OPERATION.clear()
     _RERUN_POST_FUZZ_HOOKS_BY_TAG.clear()
+
+
+@pytest.fixture(autouse=True, scope='session')
+def trick_hypothesis():
+    """In theory we're not supposed to use hypothesis'
+    strategy.example(), but fuzz-lightyear isn't using
+    hypothesis in a normal way.
+
+    HACK: Thus, let's silence the warning that hypothesis
+    logs, making a lot easier to interpret fuzz-lightyear
+    test results.
+
+    Relevant hypothesis code:
+    https://github.com/HypothesisWorks/hypothesis/blob/83a98364d30b88085adf2a0d0a1f7ca1ba2d4ce5/hypothesis-python/src/hypothesis/strategies/_internal/strategies.py#L273
+    """
+    sys.ps1 = ''


### PR DESCRIPTION
* Bump jinja to a version that doesn't cause the `collections.abc` is moved in py38 warning
* Set `sys.ps1=''` in tests so that Hypothesis thinks that we're in an interactive session, thus silencing an error that we can't really get around