### PR TITLE
Filter out hypothesis warnings

### DIFF
--- a/fuzz_lightyear/generator.py
+++ b/fuzz_lightyear/generator.py
@@ -108,9 +108,11 @@ def _add_request_to_sequence(
                 neighbor_requests = request_graph[request.operation_id]
                 # We have no idea whether a request should consume an existing
                 # resource, use a factory, or fuzz a value.
+                #
                 # However, we want to move towards building sequences of requests
                 # that only consume resources created by previous requests (the
                 # algorithm described in the original Microsoft paper)
+                #
                 # Therefore, add the request to the sequence if it shares an edge with
                 # ANY of the requests in the sequence- leaving room for factory
                 # usage, but still keeping in line with the spirit of RESTler.

--- a/fuzz_lightyear/main.py
+++ b/fuzz_lightyear/main.py
@@ -2,12 +2,14 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+import warnings
 
 import requests
 import simplejson
 import yaml
 from bravado.client import SwaggerClient
 from bravado.exception import HTTPError
+from hypothesis.errors import NonInteractiveExampleWarning
 from swagger_spec_validator.common import SwaggerValidationError    # type: ignore
 
 from .datastore import get_setup_fixtures
@@ -26,6 +28,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = parse_args(argv)
     if args.verbose:    # pragma: no cover
         log.set_debug_level(args.verbose)
+
+    # NOTE: Hypothesis warns us against using `.example()` (which we leverage
+    # during the fuzzing process), and to use `@given` instead. However, we
+    # are not using hypothesis in a conventional manner, and therefore this
+    # warning does not apply to us.
+    warnings.filterwarnings('ignore', category=NonInteractiveExampleWarning)
 
     # Setup
     message = setup_client(args.url, args.schema)

--- a/fuzz_lightyear/request.py
+++ b/fuzz_lightyear/request.py
@@ -147,6 +147,15 @@ class FuzzingRequest:
             self.fuzzed_input = self.fuzz(data)
             self.apply_post_fuzz_hooks(self.fuzzed_input, rerun=False)
         else:
+            # On the first run, self.fuzzed_input will be initialized
+            # to a dictionary. Therefore, if this request is sent again,
+            # this code path will execute, and we will want to rerun
+            # the applicable post_fuzz hooks.
+            #
+            # TODO: I wonder whether we have to distinguish between
+            # explicitly initialized `fuzzed_input`, and *actually* fuzzed
+            # input, given that the former case will technically be the
+            # *first* time the post_fuzz hook is run.
             self.apply_post_fuzz_hooks(self.fuzzed_input, rerun=True)
 
         if not auth:


### PR DESCRIPTION
In running these tests, I got really annoyed at the amount of unnecessary `hypothesis` warnings:

```
.../virtualenv_run/lib/python3.6/site-packages/hypothesis/strategies/_internal/strategies.py:273: NonInteractiveExampleWarning: The `.example()` met
hod is good for exploring strategies, but should only be used interactively.  We recommend using `@given` for tests - it performs better, saves and replays failures to avoid flakiness,
and reports minimal examples. (strategy: fixed_dictionaries({'business_id': builds(type_cast)}))
NonInteractiveExampleWarning,
```

Let's just filter them out.