### PR TITLE
Disable color printing when not printing to terminal

### DIFF
--- a/fuzz_lightyear/main.py
+++ b/fuzz_lightyear/main.py
@@ -1,8 +1,8 @@
+import warnings
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-import warnings
 
 import requests
 import simplejson

--- a/fuzz_lightyear/output/color.py
+++ b/fuzz_lightyear/output/color.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+from fuzz_lightyear.settings import get_settings
+
 
 class AnsiColor(Enum):
     RESET = '[0m'
@@ -12,6 +14,9 @@ class AnsiColor(Enum):
 
 
 def colorize(text: str, color: AnsiColor) -> str:
+    if not get_settings().enable_color:
+        return text
+
     return '\x1b{}{}\x1b{}'.format(
         color.value,
         text,

--- a/fuzz_lightyear/output/interface.py
+++ b/fuzz_lightyear/output/interface.py
@@ -17,6 +17,9 @@ from .logging import root_logger
 
 class ResultFormatter:
     def __init__(self) -> None:
+        if not sys.stdout.isatty():
+            get_settings().enable_color = False
+
         print(
             colorize(
                 formatter.format_header('fuzzing session starts', header_line='='),

--- a/fuzz_lightyear/settings.py
+++ b/fuzz_lightyear/settings.py
@@ -8,6 +8,7 @@ class Settings:
     def __init__(self) -> None:
         self.seed = random.getrandbits(128)    # type: int
         self.unicode_enabled = True            # type: bool
+        self.enable_color = True               # type: bool
 
     @property
     def seed(self) -> int:


### PR DESCRIPTION
### Summary

ANSI colorization is only good if the output is to a terminal. When it goes into a file instead, the ANSI color codes makes it hard to read. This fixes that.

### Testing

Manual testing.

**Before Change**:

```
$ make vulnerable_app
$ fuzz-lightyear http://localhost:5000/schema -f test_data > output.fuzz
$ vim output.fuzz
^[[1m======================= fuzzing session starts =======================^[[0m
Hypothesis Seed: 45681616869573565430211526758451148904

basic ^[[92m.^[[0m^[[91mE^[[0m^[[91mE^[[0m
```

**After Change**:

```
$ make vulnerable_app
$ fuzz-lightyear http://localhost:5000/schema -f test_data > output.fuzz
$ vim output.fuzz
======================= fuzzing session starts =======================
Hypothesis Seed: 242999052542582450454317716917191761814

basic .EE
```

### Notes

We could probably create a flag `--no-color` to manually enable this, but YAGNI for now.