### PR TITLE
adding --ignore-non-vulnerable flag

### DIFF
--- a/fuzz_lightyear/main.py
+++ b/fuzz_lightyear/main.py
@@ -12,6 +12,8 @@ from bravado.exception import HTTPError
 from hypothesis.errors import NonInteractiveExampleWarning
 from swagger_spec_validator.common import SwaggerValidationError    # type: ignore
 
+from .datastore import get_excluded_operations
+from .datastore import get_non_vulnerable_operations
 from .datastore import get_setup_fixtures
 from .discovery import import_fixtures
 from .generator import generate_sequences
@@ -43,6 +45,10 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     setup_fixtures(args.fixture)
     run_user_defined_setup()
+    if args.ignore_non_vulnerable:
+        get_excluded_operations().update(
+            get_non_vulnerable_operations(),
+        )
 
     outputter = run_tests(
         *args.test,

--- a/fuzz_lightyear/output/formatter.py
+++ b/fuzz_lightyear/output/formatter.py
@@ -144,6 +144,9 @@ def format_summary(
         summary = [f'{num_failures} failed', *summary]
         color = AnsiColor.RED
 
+    if not summary:
+        return colorize(format_header('No tests run!'), AnsiColor.BOLD)
+
     summary_string = '{} in {} seconds'.format(
         ', '.join(summary),
         round(timing.total_seconds(), 2),

--- a/fuzz_lightyear/supplements/exclude.py
+++ b/fuzz_lightyear/supplements/exclude.py
@@ -61,7 +61,7 @@ def operations(func: Callable) -> Callable:
         Ignoring operations specified by "tag.operation_id" in lists
             >>> @fuzz_lightyear.exclude.operations
             ... def c():
-                    return ['pets.get_pets', 'store.get_store_inventory']
+            ...     return ['pets.get_pets', 'store.get_store_inventory']
     """
     get_operations_fn = _get_formatted_operations(func)
     get_excluded_operations().update(get_operations_fn())

--- a/fuzz_lightyear/usage.py
+++ b/fuzz_lightyear/usage.py
@@ -85,6 +85,15 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
             'vulnerabilities are found).'
         ),
     )
+    parser.add_argument(
+        '--ignore-non-vulnerable',
+        action='store_true',
+        help=(
+            'Excludes all non-vulnerable operations from tests. This is '
+            'especially handy when you *only* want to check for '
+            'vulnerabilities (rather than Swagger accuracy).'
+        ),
+    )
 
     parser.add_argument(
         '--disable-unicode',

--- a/test_data/nested/another_fixture.py
+++ b/test_data/nested/another_fixture.py
@@ -10,3 +10,10 @@ def attacker_account():
             },
         },
     }
+
+
+@fuzz_lightyear.exclude.non_vulnerable_operations
+def specify_non_vulnerable_operations():
+    return (
+        'basic.get_public_listing',
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from fuzz_lightyear.datastore import _ALL_POST_FUZZ_HOOKS_BY_OPERATION

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ tox_pip_extensions_ext_venv_update = true
 passenv = SSH_AUTH_SOCK
 deps = -rrequirements-dev.txt
 commands =
-    pre-commit run --all-files
     coverage erase
     coverage run -m pytest tests
     coverage report --show-missing --include=tests/* --fail-under 98

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ tox_pip_extensions_ext_venv_update = true
 passenv = SSH_AUTH_SOCK
 deps = -rrequirements-dev.txt
 commands =
+    pre-commit run --all-files
     coverage erase
     coverage run -m pytest tests
     coverage report --show-missing --include=tests/* --fail-under 98


### PR DESCRIPTION
### Summary

There's a nuanced difference between `fuzz_lightyear.exclude.operations` and `fuzz_lightyear.exclude.non_vulnerable_operations`: the former skips over the endpoint completely, and the latter tests the endpoint, but ignores the `IDORPlugin` result.

This nuance makes an important difference when generating sequences of length n>1, or when the Swagger schema is incorrect. If the endpoint is completely excluded, the test run will be faster, since there are less total sequences to create. Furthermore, invalid Swagger schemas will be ignored as well.

For the times we want this trade-off, this PR introduces the new flag `--ignore-non-vulnerable`, which will treat excluded `non_vulnerable_operations` as completely excluded operations.