### PR TITLE
Gracefully handling case of no tests run

### DIFF
--- a/fuzz_lightyear/output/formatter.py
+++ b/fuzz_lightyear/output/formatter.py
@@ -131,6 +131,7 @@ def format_summary(
     num_failures = stats['failure']
     num_warnings = stats['warnings']
 
+    color = AnsiColor.RESET
     summary = []
     if num_passed:
         summary.append(f'{num_passed} passed')
@@ -147,10 +148,13 @@ def format_summary(
     if not summary:
         return colorize(format_header('No tests run!'), AnsiColor.BOLD)
 
-    summary_string = '{} in {} seconds'.format(
-        ', '.join(summary),
-        round(timing.total_seconds(), 2),
-    )
+    if color == AnsiColor.RESET:
+        summary_string = 'No tests run'
+    else:
+        summary_string = '{} in {} seconds'.format(
+            ', '.join(summary),
+            round(timing.total_seconds(), 2),
+        )
 
     return colorize(
         colorize(


### PR DESCRIPTION
This fixes this traceback:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/nail/home/aaronloo/pg/msg_pages/fuzzing/main.py", line 100, in <module>
    main()
  File "/nail/home/aaronloo/pg/msg_pages/fuzzing/main.py", line 96, in main
    return run_fuzz_lightyear(sys.argv[1:])
  File "/nail/home/aaronloo/pg/msg_pages/virtualenv_run/lib/python3.6/site-packages/fuzz_lightyear/main.py", line 47, in main
    outputter.show_results()
  File "/nail/home/aaronloo/pg/msg_pages/virtualenv_run/lib/python3.6/site-packages/fuzz_lightyear/output/interface.py", line 108, in show_results
    datetime.now() - self.start_time,
  File "/nail/home/aaronloo/pg/msg_pages/virtualenv_run/lib/python3.6/site-packages/fuzz_lightyear/output/formatter.py", line 155, in format_summary
    color,
UnboundLocalError: local variable 'color' referenced before assignment
```