### PR TITLE
bug fix: sequences are marked successful only if they complete

### DIFF
--- a/fuzz_lightyear/result.py
+++ b/fuzz_lightyear/result.py
@@ -18,4 +18,4 @@ class FuzzingResult:
         self.exception_info = {}            # type: Dict[str, Any]
 
     def is_successful(self) -> bool:
-        return bool(self.responses)
+        return bool(self.responses) and len(self.responses) == len(self.requests)

--- a/tests/integration/generator_test.py
+++ b/tests/integration/generator_test.py
@@ -121,7 +121,8 @@ def test_length_three(mock_client):
     sequences = []
     for result in generate_sequences(3):
         if not result.requests[-1].operation_id.endswith('will_throw_error'):
-            result.responses = True
+            # This is a hacky way to mock responses, without actually fuzzing it.
+            result.responses = [True for _ in range(len(result.requests))]
 
         sequences.append(result.requests)
 

--- a/tests/integration/result_test.py
+++ b/tests/integration/result_test.py
@@ -1,0 +1,52 @@
+import pytest
+from bravado.exception import HTTPError
+
+from fuzz_lightyear.request import FuzzingRequest
+from fuzz_lightyear.result import FuzzingResult
+from fuzz_lightyear.runner import validate_sequence
+
+
+@pytest.mark.parametrize(
+    'sequence',
+    (
+        [
+            FuzzingRequest(
+                tag='sequence',
+                operation_id='post_alpha_one',
+            ),
+        ],
+        [
+            FuzzingRequest(
+                tag='sequence',
+                operation_id='get_alpha_two',
+            ),
+        ],
+    ),
+)
+def test_successful_sequence(mock_client, sequence):
+    result = FuzzingResult(sequence)
+    validate_sequence(result.requests, result.responses)
+
+    assert result.is_successful()
+
+
+def test_failed_sequence_should_not_be_successful(mock_client):
+    result = FuzzingResult([
+        FuzzingRequest(
+            tag='sequence',
+            operation_id='post_alpha_one',
+        ),
+        FuzzingRequest(
+            tag='constant',
+            operation_id='get_will_throw_error',
+        ),
+        FuzzingRequest(
+            tag='sequence',
+            operation_id='get_alpha_two',
+        ),
+    ])
+
+    with pytest.raises(HTTPError):
+        validate_sequence(result.requests, result.responses)
+
+    assert not result.is_successful()


### PR DESCRIPTION
This addresses #56 with automated test cases.