### PR TITLE
Pass positional arguments to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ passenv = SSH_AUTH_SOCK
 deps = -rrequirements-dev.txt
 commands =
     coverage erase
-    coverage run -m pytest tests
+    coverage run -m pytest {posargs:tests}
     coverage report --show-missing --include=tests/* --fail-under 98
     coverage report --show-missing --include=fuzz_lightyear/* --fail-under 95
     mypy fuzz_lightyear


### PR DESCRIPTION
Sometimes it's not necessary to run all tests. This change allows to pass arguments to pytest (e.g. `tox -- tests/integration/result_test.py`) meanwhile keeps running all tests by default.