### PR TITLE
Update Github action PyPi publish version

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -32,4 +32,4 @@ jobs:
     - name: Build package
       run: python setup.py sdist bdist_wheel
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
- The version set for `gh-action-pypi-publish` is 3 years old and the deploy is failing. 
- Setting the version to `@release/v1` as mentioned here: https://github.com/marketplace/actions/pypi-publish