### PR TITLE
Fix: 'long_description' error when publishing to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,16 @@ VERSION = None      # needed for flake8
 with open(local_file('fuzz_lightyear/version.py')) as f:
     exec(f.read())
 
+with open('README.md', encoding='utf-8') as f:
+    long_description = f.read()
 
 setup(
     name='fuzz_lightyear',
     packages=find_packages(exclude=(['test*', 'tmp*'])),
     version=VERSION,
     description='Vulnerability Discovery through Stateful Swagger Fuzzing',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     license='Copyright Yelp, Inc. 2019',
     author=', '.join([
         'Aaron Loo <aaronloo@yelp.com>',


### PR DESCRIPTION
### Overview
- Publish to PyPI [workflow](https://github.com/Yelp/fuzz-lightyear/actions/runs/7827988649/job/21356943209) fails with below error:
```sh
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         No content rendered from RST source. 
```

- Although, we don't have `long_description` field in `setup.py`, workflow fails 

- Some discussions have suggested to add `long_description_content_type` to fix this error
  - https://github.com/pypa/gh-action-pypi-publish/discussions/191
  - https://github.com/pypa/gh-action-pypi-publish/discussions/209
- Adding `long_description` field along with content_type for better description in the pypi project page